### PR TITLE
Runtime fix for FGPUL-33

### DIFF
--- a/pulsar/connection/connection.go
+++ b/pulsar/connection/connection.go
@@ -85,7 +85,7 @@ func (*Factory) NewManager(settings map[string]interface{}) (connection.Manager,
 	if strings.Index(s.URL, "pulsar+ssl") >= 0 {
 		if keystoreDir == "" {
 			clientOpts.TLSTrustCertsFilePath = s.CaCert
-		} else {
+		} else if !s.AllowInsecure {
 			clientOpts.TLSTrustCertsFilePath = keystoreDir + string(os.PathSeparator) + "cacert.pem"
 		}
 	}


### PR DESCRIPTION
If "allow insecure" is set then the server's ca-cert is optional.  Allow ignore that field when making the connection.